### PR TITLE
Fix SVG DATA for FF and IE

### DIFF
--- a/lib/iconify.js
+++ b/lib/iconify.js
@@ -34,7 +34,7 @@ imacss.partialtransform = function partialtransform (glob, css) {
                     image.contents = new Buffer(result.data);
                 });
 
-                image.datauri = 'data:'+image.mime+';utf8,'+image.contents.toString('utf-8');
+                image.datauri = 'data:'+image.mime+';charset=UTF-8,'+encodeURIComponent(image.contents.toString('utf-8'));
             }
 
             this.push(image);


### PR DESCRIPTION
FF and IE doesn't support plain embed SVG Code, uri encoding is necessary :-) first testing looks really fine, the guys from filamentgroup did something more, their are using the US-ASCII encoding for the embeded, encoded svg data
