### PR TITLE
Make generated svg css compatible with grunticon embed

### DIFF
--- a/lib/iconify.js
+++ b/lib/iconify.js
@@ -34,7 +34,7 @@ imacss.partialtransform = function partialtransform (glob, css) {
                     image.contents = new Buffer(result.data);
                 });
 
-                image.datauri = 'data:'+image.mime+';charset=UTF-8,'+encodeURIComponent(image.contents.toString('utf-8'));
+                image.datauri = 'data:'+image.mime+';charset=US-ASCII,'+encodeURIComponent(image.contents.toString('utf-8'));
             }
 
             this.push(image);


### PR DESCRIPTION
The generated svg css files are not compatible with grunticons embed option. 
By switching the decoding they can be embedded by  the grunticon javascript loader (data-grunticon-embed). 

Compatibility tested in firefox, chrome, safari and ie11.
