### PR TITLE
Use `gulp-sass@^2.0.4` to fix Node v4.2.1 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "through2": "~0.6.3",
     "imacss": "~0.3.0",
     "gulp-svg2png": "~0.3.0",
-    "gulp-sass": "~1.3.3",
+    "gulp-sass": "^2.0.4",
     "svgo": "~0.5.0",
     "del": "~1.1.1",
     "xmldom": "~0.1.19"


### PR DESCRIPTION
Support `NodeJS v4.2.1` by upgrading `gulp-sass` depedency to version `^2.0.4` which fixes the error:

```
./node_modules/gulp-iconify/node_modules/gulp-sass/node_modules/node-sass/lib/index.js:22
    throw new Error('`libsass` bindings not found. Try reinstalling `node-sass`?');
    ^

Error: `libsass` bindings not found. Try reinstalling `node-sass`?
    at getBinding (./node_modules/gulp-iconify/node_modules/gulp-sass/node_modules/node-sass/lib/index.js:22:11)
    at Object.<anonymous> (./node_modules/gulp-iconify/node_modules/gulp-sass/node_modules/node-sass/lib/index.js:188:23)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (./node_modules/gulp-iconify/node_modules/gulp-sass/index.js:3:17)
    at Module._compile (module.js:435:26)
```
