### PR TITLE
Update gulp-sass to work with npm 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "through2": "~0.6.3",
     "imacss": "~0.3.0",
     "gulp-svg2png": "~0.3.0",
-    "gulp-sass": "~1.3.3",
+    "gulp-sass": "~2.1.0",
     "svgo": "~0.5.0",
     "del": "~1.1.1",
     "xmldom": "~0.1.19"


### PR DESCRIPTION
See issue [here](https://github.com/sass/node-sass/issues/1061)
Tested on node 0.12.7 + npm 2.11.3 and node 5.0.0 + npm 3.3.6
