### PR TITLE
Update svg2png to v1.0.0 and add configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This simple call defaults to the following:
 - If SVG has no height attribute, the default fallback will be 200px
 - The default styleTemplate fill be used (examples shown below)
 - The default styleTemplate will *not* use the height/width slugs
+- See [gulp-svg2png](https://github.com/akoenig/gulp-svg2png) for default settings
 
 ###Customized example
 ```javascript
@@ -49,6 +50,11 @@ gulp.task('default', function() {
                     { mergePaths: false }
                 ]
             }
+        },
+        svg2pngOptions: {
+            scaling: 1.0,
+            verbose: true,
+            concurrency: null
         }
     });
 });

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ module.exports = function(opts) {
             .pipe(gulp.dest(opts.scssOutput));
 
         var stream = gulp.src(opts.src)
-            .pipe(svg2png())
+            .pipe(svg2png(1.0, true, opts.concurrency || null))
                 .pipe(gulp.dest(opts.pngOutput))
                     .pipe(iconify({
                         styleTemplate: opts.styleTemplate,

--- a/index.js
+++ b/index.js
@@ -64,6 +64,11 @@ function setFallbacks(opts) {
         warning.svgoOptions = "Info: No SVGO options defined, enabling SVGO by default.";
     }
 
+    if(!opts.svg2pngOptions) {
+        opts.svg2pngOptions = {};
+        warning.svg2pngOptions = "Info: No svg2png options defined. Using default settings.";
+    }
+
     if(!opts.defaultWidth) {
         opts.defaultWidth = "300px";
         warning.defaultWidth = "Info: No defaultWidth defined. Using fallback ("+opts.defaultWidth+") if SVG has no width.";
@@ -104,7 +109,7 @@ module.exports = function(opts) {
             .pipe(gulp.dest(opts.scssOutput));
 
         var stream = gulp.src(opts.src)
-            .pipe(svg2png(1.0, true, opts.concurrency || null))
+            .pipe(svg2png(opts.svg2pngOptions.scaling, opts.svg2pngOptions.verbose, opts.svg2pngOptions.concurrency))
                 .pipe(gulp.dest(opts.pngOutput))
                     .pipe(iconify({
                         styleTemplate: opts.styleTemplate,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-iconify",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "'A mystical CSS icon solution', grunticon-like build system.",
   "author": "Gabrijel Gavranović <gabrijel@gavro.nl> (http://gavro.nl)",
   "keywords": [
@@ -26,8 +26,8 @@
     "through": "~2.3.6",
     "through2": "~0.6.3",
     "imacss": "~0.3.0",
-    "gulp-svg2png": "git+https://github.com/nihaopaul/gulp-svg2png.git#feature/parallel-tasks",
-    "gulp-sass": "~1.3.3",
+    "gulp-svg2png": "~1.0.0",
+    "gulp-sass": "~2.1.0",
     "svgo": "~0.5.0",
     "del": "~1.1.1",
     "xmldom": "~0.1.19"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "through": "~2.3.6",
     "through2": "~0.6.3",
     "imacss": "~0.3.0",
-    "gulp-svg2png": "~0.3.0",
+    "gulp-svg2png": "git+https://github.com/nihaopaul/gulp-svg2png.git#feature/parallel-tasks",
     "gulp-sass": "~1.3.3",
     "svgo": "~0.5.0",
     "del": "~1.1.1",


### PR DESCRIPTION
The goal of this update is to benefit from the new **concurrency** parameter. This option let the user restrict the number of phantomjs instances that could run concurrently.

It is a life saving option when converting a lot of images (=> lot of phantomjs instance => "fork bomb") on obsolete computer or poorly sized VMs.
