### PR TITLE
svg dimensions from viewBox if no width/height.

### DIFF
--- a/lib/iconify.js
+++ b/lib/iconify.js
@@ -14,6 +14,13 @@ var getDimensions = function (type, image) {
         var doc = new dom.DOMParser().parseFromString(image.contents.toString('utf-8'));
         dimensions.width = Math.round(doc.documentElement.getAttribute('width'));
         dimensions.height = Math.round(doc.documentElement.getAttribute('height'));
+        if (!dimensions.width || !dimensions.height) {
+            var vb = doc.documentElement.getAttribute('viewBox');
+            if (vb) {
+                dimensions.width = vb.split(" ")[2];
+                dimensions.height = vb.split(" ")[3];
+            }           
+        }
     } else {
         var hexString = image.contents.toString("hex");
         var i = 16, l;


### PR DESCRIPTION
Added simple non-breaking addition to look up SVG's viewBox property in case there no width/height properties. It's a crime to not event attemp to do that as ViewBox is used rather often (i had some screwed up icons in my scss due them having no width/height but viewBox).